### PR TITLE
Remove binary Android assets and document regeneration steps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,7 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+# Android/Gradle wrapper artifacts
+android/gradle/wrapper/gradle-wrapper.jar
+# Local-only reminder audio assets
+android/app/src/main/res/raw/tablet_time.wav

--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
-# Health-Reminder
+# Health Reminder
+
+A Flutter application for managing health reminders and notifications.
+
+## Android contributor notes
+
+### Gradle wrapper JAR
+
+The Gradle wrapper JAR (`android/gradle/wrapper/gradle-wrapper.jar`) is intentionally not tracked in git.
+If you need the wrapper locally, regenerate it with:
+
+```bash
+cd android
+./gradlew wrapper --gradle-version <version-you-need>
+```
+
+or, if the wrapper scripts are also missing, run:
+
+```bash
+gradle wrapper --gradle-version <version-you-need>
+```
+
+This command recreates the wrapper JAR without committing the binary to the repository.
+
+### Launcher icons
+
+Android launcher icons are defined via XML/vector resources in `android/app/src/main/res` so
+no binary PNGs need to be stored in git. If you update the icon, modify the vector drawables
+instead of adding bitmap assets.
+
+### Tablet reminder sound
+
+The repository does not ship the `tablet_time.wav` notification sound. To test or ship a
+custom sound, place your WAV file at `android/app/src/main/res/raw/tablet_time.wav` locally
+(or configure a different filename in the Android manifest metadata). The build will succeed
+without this optional file.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.health_reminder">
+
+    <application
+        android:label="@string/app_name"
+        android:icon="@mipmap/ic_launcher"
+        android:roundIcon="@mipmap/ic_launcher_round">
+        <meta-data
+            android:name="health_reminder.notification_sound"
+            android:value="@string/notification_sound_placeholder" />
+    </application>
+</manifest>

--- a/android/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/android/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,26 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <group android:scaleX="0.58"
+        android:scaleY="0.58"
+        android:translateX="22.68"
+        android:translateY="22.68">
+        <path
+            android:fillColor="#FFFFFFFF"
+            android:pathData="M54,0C24.176,0 0,24.176 0,54s24.176,54 54,54 54,-24.176 54,-54S83.824,0 54,0z" />
+        <path
+            android:fillColor="#FF4CAF50"
+            android:pathData="M54,9a45,45 0 1,0 45,45 45.051,45.051 0 0,0 -45,-45zm0,82a37,37 0 1,1 37,-37 37.042,37.042 0 0,1 -37,37z" />
+        <path
+            android:fillColor="#FF4CAF50"
+            android:pathData="M54,27a27,27 0 1,0 27,27 27.031,27.031 0 0,0 -27,-27zm0,46a19,19 0 1,1 19,-19 19.022,19.022 0 0,1 -19,19z" />
+        <path
+            android:fillColor="#FF4CAF50"
+            android:pathData="M54,36a18,18 0 1,0 18,18 18.021,18.021 0 0,0 -18,-18zm0,29a11,11 0 1,1 11,-11 11.013,11.013 0 0,1 -11,11z" />
+        <path
+            android:fillColor="#FF4CAF50"
+            android:pathData="M58.5,45h-6v12h12v-6h-6z" />
+    </group>
+</vector>

--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/android/app/src/main/res/values/ic_launcher_background.xml
+++ b/android/app/src/main/res/values/ic_launcher_background.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="ic_launcher_background">#2E7D32</color>
+</resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Health Reminder</string>
+    <string name="notification_sound_placeholder">Provide tablet_time.wav in res/raw or update this value locally.</string>
+</resources>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,8 +18,6 @@ dependencies:
 
 flutter:
   uses-material-design: true
-  assets:
-    - assets/tablet_time.wav
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- ignore the Gradle wrapper JAR and document how to regenerate it when needed
- replace Android launcher PNGs with adaptive/vector drawables and supply minimal manifest resources
- remove the committed tablet_time.wav asset while documenting how to provide the optional sound locally

## Testing
- Not run (Flutter SDK not available in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68dfc48129708326a4d0e6589b36a442